### PR TITLE
Fix TypeScript error

### DIFF
--- a/src/components/logger/Logger.tsx
+++ b/src/components/logger/Logger.tsx
@@ -49,7 +49,7 @@ const LogEntry = ({
     message,
   }: {
     message: StreamingLog["message"];
-  }) => ReactNode;
+  }) => JSX.Element;
 }): JSX.Element => (
   <li
     className={cn(


### PR DESCRIPTION
Fixed TypeScript compilation error in Logger.tsx by changing MessageComponent's return type from ReactNode to JSX.Element, so component always returns a renderable element instead of potentially undefined values.