### PR TITLE
fix: handle screen share termination from browser UI

### DIFF
--- a/src/components/control-tray/ControlTray.tsx
+++ b/src/components/control-tray/ControlTray.tsx
@@ -53,7 +53,7 @@ const MediaStreamButton = memo(
       <button className="action-button" onClick={start}>
         <span className="material-symbols-outlined">{offIcon}</span>
       </button>
-    ),
+    )
 );
 
 function ControlTray({
@@ -83,7 +83,7 @@ function ControlTray({
   useEffect(() => {
     document.documentElement.style.setProperty(
       "--volume",
-      `${Math.max(5, Math.min(inVolume * 200, 8))}px`,
+      `${Math.max(5, Math.min(inVolume * 200, 8))}px`
     );
   }, [inVolume]);
 
@@ -141,6 +141,35 @@ function ControlTray({
       clearTimeout(timeoutId);
     };
   }, [connected, activeVideoStream, client, videoRef]);
+
+  useEffect(() => {
+    if (!activeVideoStream) return;
+
+    const tracks = activeVideoStream.getTracks();
+
+    const handleTrackEnded = (): void => {
+      // Stop all active streams
+      videoStreams.forEach((streamControl) => {
+        if (streamControl.isStreaming) {
+          streamControl.stop();
+        }
+      });
+
+      setActiveVideoStream(null);
+      onVideoStreamChange(null);
+    };
+
+    // Attach listeners to all tracks
+    tracks.forEach((track) => {
+      track.addEventListener("ended", handleTrackEnded);
+    });
+
+    return () => {
+      tracks.forEach((track) => {
+        track.removeEventListener("ended", handleTrackEnded);
+      });
+    };
+  }, [activeVideoStream, onVideoStreamChange, videoStreams]);
 
   //handler for swapping from one video-stream to the next
   const changeStreams = (next?: UseMediaStreamResult) => async () => {


### PR DESCRIPTION

![Screenshot 2025-02-26 at 21 51 37](https://github.com/user-attachments/assets/41b69fa6-7e98-47dd-ade9-f59896d3d312)
When screen sharing is stopped from the browser's native UI controls (rather than the app's control buttons), the application now properly:

- Detects stream termination via MediaStreamTrack 'ended' event
- Cleans up all active streams
- Updates UI state accordingly
- Prevents black screen artifacts

Technical changes:
- Added MediaStreamTrack event listeners in useEffect
- Improved stream cleanup with isStreaming check
- Added proper TypeScript types for event handlers